### PR TITLE
#184581339 Admin should be able to set roles/permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ With correct token you get the following:
   "message": "user Ange She sucessfully made admin"
 }
 ```
-## Change password:
+
+### Change password:
 
 `PATCH /users/change-password`
 
@@ -361,4 +362,30 @@ if you are a seller you will get this response:
 - product must be in your collection
 - note: `token is required`
 
-this will change product availability to true if it was false or false if it was true
+   `PATCH /users/change-password`
+### Setting role/permission to the given user
+- First yoou logged in as Admin to be allowed to set role
+- get the token and put it in bearer
+- then click Authorize
+
+`patch /users/:id/role`
+- where id is the id of user you want to give a given role
+
+Example response body:
+```
+{
+  "role": "<role you want to give user>"
+}
+```
+With the correct token of admin and correct id of user  you get the following:
+- Example Response: 
+```
+{ 
+  "token": "<string>"
+  "username: "string",
+  "email": "string",
+  "gender": "string",
+  "role": "updated role"
+}
+```
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "eslint": "^8.35.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.27.5",
-        "nodemon": "*",
+        "nodemon": "^2.0.21",
         "sequelize-cli": "^6.6.0",
         "supertest": "^6.3.3",
         "swagger-jsdoc": "^6.2.8",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eslint": "^8.35.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.27.5",
-    "nodemon": "*",
+    "nodemon": "^2.0.21",
     "sequelize-cli": "^6.6.0",
     "supertest": "^6.3.3",
     "swagger-jsdoc": "^6.2.8",

--- a/src/configs/cloudinary.js
+++ b/src/configs/cloudinary.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 import cloudinary from 'cloudinary';
 
 cloudinary.config({

--- a/src/configs/multer.js
+++ b/src/configs/multer.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line import/no-unresolved
+// eslint-disable-next-line import/no-unresolved, import/no-extraneous-dependencies
 import multer from 'multer';
 import path from 'path';
 

--- a/src/controllers/users.controllers.js
+++ b/src/controllers/users.controllers.js
@@ -3,6 +3,7 @@ import bcrypt from 'bcrypt';
 // eslint-disable-next-line import/no-unresolved, import/no-extraneous-dependencies
 import jwt from 'jsonwebtoken';
 import dotenv from 'dotenv';
+// eslint-disable-next-line import/no-named-as-default
 import User from '../services/user.services';
 // eslint-disable-next-line import/no-duplicates
 import db from '../database/models';
@@ -94,6 +95,23 @@ export default class Users {
       message: 'Your account has been verified successfully!',
       verified: true,
     });
+  }
+
+  static async setRole(req, res) {
+    try {
+      const { role } = req.body;
+      const { email } = req.params;
+      await User.setRole(role, email);
+      return res.status(200).json({
+        status: 200,
+        message: 'Role assigned to the user successfully',
+      });
+    } catch (error) {
+      return res.status(500).json({
+        status: 500,
+        message: error.message,
+      });
+    }
   }
 
   /**

--- a/src/docs/users.js
+++ b/src/docs/users.js
@@ -279,6 +279,65 @@
  *         description: Internal server error
  *       default:
  *         description: Unexpected error
+ *
+ * @swagger
+ * /users/role/{email}:
+ *   patch:
+ *     summary: Assigning role to a given user.
+ *     tags:
+ *         - Users
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: email
+ *         required: true
+ *         description: Email of the user you want to set a role to.
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               role:
+ *                   type: string
+ *     responses:
+ *       '200':
+ *         description: Role assigned to the user successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   description: A success message.
+ *       '404':
+ *         description: The user with that id was not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: integer
+ *                   example: 404
+ *                 message:
+ *                   type: string
+ *                   description: error message.
+ *       '500':
+ *         description: Internal server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 Error:
+ *                   type: string
+ *                   description: error message.
  */
 
 /**

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -38,5 +38,7 @@ routes.post('/disable-mfa', isAuthenticated, Users.disableMfa);
 routes.post('/login', loginValidate, Users.login);
 routes.get('/profile', isAuthenticated, Users.getProfile);
 routes.patch('/profile', isAuthenticated, profileVatidate, Users.editProfile);
+// eslint-disable-next-line no-undef
+routes.patch('/role/:email', isAuthenticated, checkRole(['admin']), Users.setRole);
 
 export default routes;

--- a/src/services/user.services.js
+++ b/src/services/user.services.js
@@ -4,7 +4,7 @@
 /* eslint-disable object-shorthand */
 /* eslint-disable require-jsdoc */
 import bcrypt from 'bcrypt';
-// eslint-disable-next-line import/no-extraneous-dependencies
+// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
 import nodemailer from 'nodemailer';
 // eslint-disable-next-line import/named
 import { users } from '../database/models';
@@ -108,5 +108,9 @@ export default class User {
       if (err) return console.error('ERROR SENDING MAIL: ', err);
       console.log('MAIL SENT: ', info.response);
     });
+  }
+
+  static async setRole(role, email) {
+    await users.update({ role }, { where: { email, }, });
   }
 }

--- a/tests/users.test.js
+++ b/tests/users.test.js
@@ -237,14 +237,15 @@ describe('testing creation of admin', () => {
       .request(app)
       .post('/users/login')
       .send({ email: 'inezapatience2@gmail.com', password: '123@Pass' });
-    const { token: authToken } = res.body;
+    // eslint-disable-next-line no-shadow
+    const { token } = res.body;
     expect(res).to.have.status(200);
     expect(res.body).to.have.property('token');
 
     const verifyRes = await chai
       .request(app)
-      .patch(`/users/create-admin/${email}`)
-      .set('Authorization', `Bearer ${authToken}`);
+      .patch(`/users/Create-admin/${email}`)
+      .set('Authorization', `Bearer ${token}`);
     chai.expect(verifyRes).to.have.status(200);
   });
 });
@@ -256,13 +257,57 @@ it('should return 404 if a user is not found', async () => {
     .request(app)
     .post('/users/login')
     .send({ email: 'inezapatience2@gmail.com', password: '123@Pass' });
-  const { token: authToken } = res.body;
+  // eslint-disable-next-line no-shadow
+  const { token } = res.body;
   expect(res).to.have.status(200);
   expect(res.body).to.have.property('token');
 
   const verifyRes = await chai
     .request(app)
-    .patch(`/users/create-admin/${Invalidemail}`)
-    .set('Authorization', `Bearer ${authToken}`);
+    .patch(`/users/Create-admin/${Invalidemail}`)
+    .set('Authorization', `Bearer ${token}`);
   chai.expect(verifyRes).to.have.status(404);
+});
+
+const Email = 'ange@gmail.com';
+describe('testing setting role/permission to a given user', () => {
+  it('should return change the role of user to a seted role', async () => {
+    const res = await chai
+      .request(app)
+      .post('/users/login')
+      .send({ email: 'inezapatience2@gmail.com', password: '123@Pass', });
+    // eslint-disable-next-line no-shadow
+    const { token } = res.body;
+    expect(res).to.have.status(200);
+    expect(res.body).to.have.property('token');
+
+    const verifyRes = await chai
+      .request(app)
+      .patch(`/users/role/${Email}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        role: 'seller',
+      });
+    chai.expect(verifyRes).to.have.status(200);
+  });
+});
+
+const invalidEmail = 'an@gmail.com';
+
+it('should return 401 if a user is not found', async () => {
+  const res = await chai
+    .request(app)
+    .post('/users/login')
+    .send({ email: 'inezapatience2@gmail.com', password: '123@Pass' });
+  expect(res).to.have.status(200);
+  expect(res.body).to.have.property('token');
+
+  const verifyRes = await chai
+    .request(app)
+    .patch(`/users/role/${invalidEmail}`)
+    .set('Authorization', `Bearer ${token}`)
+    .send({
+      role: 'seller',
+    });
+  chai.expect(verifyRes).to.have.status(401);
 });


### PR DESCRIPTION
#### What does this PR do?

This is to make Admin able to set roles/permissions to a given user

#### Description of Task to be completed?

GIVEN there are multiple users on the system and an admin
WHEN admin assigns a particular user to a particular role
THEN the user can only perform actions allowed by their role.

#### How should this be manually tested?

1. run npm install
2. run npm run migrate:all
3. run npm run start
4. Login only as Admin
5. put the token into the Bearer Token body
6. get the id of the user you want to assign any role
7. Set role by PACH request at /users/role/:id 

#### Any background context you want to provide?

to revoke the role assigned to the given user you set other role to him/her another role different to first one

#### What are the relevant pivotal tracker/Trello stories?

https://www.pivotaltracker.com/story/show/184581339

#### Screenshots (if appropriate)

<img width="1440" alt="Screen Shot 2023-03-15 at 12 12 59" src="https://user-images.githubusercontent.com/118928495/225287846-889d169e-59fb-4b0d-9ef2-d56aee1457d4.png">

<img width="1440" alt="Screen Shot 2023-03-15 at 12 21 43" src="https://user-images.githubusercontent.com/118928495/225287949-2e06d70e-9ce2-4145-87cf-3ee2ebf467c5.png">


#### Questions:
