### PR TITLE
#184581357 A user should be able to mark one/all Notification as read

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,7 @@
   },
   "rules": {
     "func-names": "off",
-    "no-console": 1,
+    "no-console":"off",
     "one-var": 0,
     "one-var-declaration-per-line": 0,
     "new-cap": 0,

--- a/.hound.yml
+++ b/.hound.yml
@@ -3,6 +3,7 @@ ignore:
   - node_modules/
   - coverage/
   - tests/
+  - src/database/migrations
 
 # Specify the rules that HoundCI should follow for JavaScript files.
 javascript:

--- a/.hound.yml
+++ b/.hound.yml
@@ -3,7 +3,7 @@ ignore:
   - node_modules/
   - coverage/
   - tests/
-  - src/database/migrations
+  - src/database/migrations 
 
 # Specify the rules that HoundCI should follow for JavaScript files.
 javascript:

--- a/README.md
+++ b/README.md
@@ -772,3 +772,14 @@ you will get this response
     "createdAt": "2023-03-25T11:38:57.712Z"
   }
 }
+
+## A user should be able to mark one/all notifications as read (needs login)
+```
+ - To mark notification as read make the following request
+    - `POST /notification/read/{notificationId}`
+ - To mark notification as unread make the following request
+    - `POST /notification/unread/{notificationId}`
+ - To mark all single user notifications as read make the following request
+    - `POST /notification/read/all`
+
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "cron": "^2.2.0",
         "dotenv": "^16.0.3",
         "eslint-config-airbnb": "^19.0.4",
+        "eslint-config-prettier": "^8.8.0",
         "express": "^4.18.2",
         "express-session": "^1.17.3",
         "http": "^0.0.1-security",
@@ -49,6 +50,7 @@
         "uuidv4": "^6.2.13"
       },
       "devDependencies": {
+        "@babel/eslint-parser": "^7.21.3",
         "@babel/plugin-transform-runtime": "^7.21.0",
         "babel-plugin-add-module-exports": "^1.0.4",
         "babel-plugin-istanbul": "^6.1.1",
@@ -230,6 +232,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/eslint-parser": {
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.21.3.tgz",
+      "integrity": "sha512-kfhmPimwo6k4P8zxNs8+T7yR44q1LdpsZdE1NkCsVlfiuTPRfnGgjaF8Qgug9q9Pou17u6wneYF0lDCZJATMFg==",
+      "dev": true,
+      "dependencies": {
+        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.11.0",
+        "eslint": "^7.5.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@babel/eslint-parser/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@babel/generator": {
@@ -2068,6 +2097,37 @@
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
       "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
       "optional": true
+    },
+    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
+      "version": "5.1.1-v1",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
+      "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
+      "dev": true,
+      "dependencies": {
+        "eslint-scope": "5.1.1"
+      }
+    },
+    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4205,6 +4265,17 @@
       "peerDependencies": {
         "eslint": "^7.32.0 || ^8.2.0",
         "eslint-plugin-import": "^2.25.2"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -10486,6 +10557,25 @@
         "semver": "^6.3.0"
       }
     },
+    "@babel/eslint-parser": {
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.21.3.tgz",
+      "integrity": "sha512-kfhmPimwo6k4P8zxNs8+T7yR44q1LdpsZdE1NkCsVlfiuTPRfnGgjaF8Qgug9q9Pou17u6wneYF0lDCZJATMFg==",
+      "dev": true,
+      "requires": {
+        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
+      }
+    },
     "@babel/generator": {
       "version": "7.21.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.1.tgz",
@@ -11738,6 +11828,33 @@
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
       "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
       "optional": true
+    },
+    "@nicolo-ribaudo/eslint-scope-5-internals": {
+      "version": "5.1.1-v1",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
+      "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
+      "dev": true,
+      "requires": {
+        "eslint-scope": "5.1.1"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+          "dev": true
+        }
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -13507,6 +13624,12 @@
         "object.entries": "^1.1.5",
         "semver": "^6.3.0"
       }
+    },
+    "eslint-config-prettier": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.7",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "cron": "^2.2.0",
     "dotenv": "^16.0.3",
     "eslint-config-airbnb": "^19.0.4",
+    "eslint-config-prettier": "^8.8.0",
     "express": "^4.18.2",
     "express-session": "^1.17.3",
     "http": "^0.0.1-security",
@@ -66,6 +67,7 @@
     "uuidv4": "^6.2.13"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "^7.21.3",
     "@babel/plugin-transform-runtime": "^7.21.0",
     "babel-plugin-add-module-exports": "^1.0.4",
     "babel-plugin-istanbul": "^6.1.1",

--- a/src/controllers/notification.controller.js
+++ b/src/controllers/notification.controller.js
@@ -1,0 +1,60 @@
+/* eslint-disable require-jsdoc */
+import NotificationServices from '../services/notification.services';
+
+export default class NotificationController {
+  static async getAllNotifications(req, res) {
+    try {
+      const notifications = await NotificationServices.getAllNotifications(
+        req.user.id
+      );
+      return res.status(200).json({ status: 200, notifications });
+    } catch (error) {
+      return res.status(500).json({ status: 500, error: error.message });
+    }
+  }
+
+  static async deleteNotification(req, res) {
+    try {
+      const response = await NotificationServices.deleteNotification({
+        notId: req.params.id,
+        userId: req.user.id,
+      });
+      if (response === 'not exist') {
+        return res
+          .status(404)
+          .json({ status: 404, error: "Notification doesn't exist" });
+      }
+      if (response === 'forbidden') {
+        return res.status(403).json({
+          status: 403,
+          error: 'You are not the recipient of the notification',
+        });
+      }
+      return res
+        .status(202)
+        .json({ status: 202, message: 'Notification deleted' });
+    } catch (error) {
+      return res.status(500).json({ status: 500, error: 'Server error' });
+    }
+  }
+
+  static async markAllAsRead(req, res) {
+    return NotificationServices.markAllNotificationAsRead(req.user.id, res);
+  }
+
+  static async markAsRead(req, res) {
+    return NotificationServices.markNotificationAsReadOrUnread(
+      req.params.notificationId,
+      res,
+      true
+    );
+  }
+
+  static async markAsUnread(req, res) {
+    return NotificationServices.markNotificationAsReadOrUnread(
+      req.params.notificationId,
+      res,
+      false
+    );
+  }
+}

--- a/src/database/migrations/20230322072543-create-chat.js
+++ b/src/database/migrations/20230322072543-create-chat.js
@@ -3,7 +3,7 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.createTable('Chats', {
+    await queryInterface.createTable('Chat', {
       id: {
         allowNull: false,
         primaryKey: true,
@@ -40,6 +40,6 @@ module.exports = {
     });
   },
   async down(queryInterface, Sequelize) {
-    await queryInterface.dropTable('Chats');
+    await queryInterface.dropTable('Chat');
   }
 };

--- a/src/database/migrations/20230326193627-notifications-table.js
+++ b/src/database/migrations/20230326193627-notifications-table.js
@@ -1,0 +1,39 @@
+/** @type {import('sequelize-cli').Migration} */
+export default {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('notifications', {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+      },
+      receiverId: {
+        type: Sequelize.UUID,
+      },
+      isRead: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+      },
+      message: {
+        type: Sequelize.STRING,
+      },
+      type: {
+        type: Sequelize.STRING,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+
+  // eslint-disable-next-line no-unused-vars
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('notifications');
+  }
+};

--- a/src/database/models/chat.js
+++ b/src/database/models/chat.js
@@ -1,8 +1,6 @@
 /* eslint-disable require-jsdoc */
 /* eslint-disable valid-jsdoc */
-const {
-  Model
-} = require('sequelize');
+const { Model } = require('sequelize');
 
 module.exports = (sequelize, DataTypes) => {
   class Chat extends Model {
@@ -14,7 +12,7 @@ module.exports = (sequelize, DataTypes) => {
     static associate(models) {
       models.users.hasMany(Chat, {
         foreignKey: 'userId',
-        onDelete: 'CASCADE'
+        onDelete: 'CASCADE',
       });
       Chat.belongsTo(models.users, {
         foreignKey: 'userId',
@@ -33,15 +31,16 @@ module.exports = (sequelize, DataTypes) => {
       room: {
         type: DataTypes.STRING,
         default: 'brogrammers',
-        allowNull: false
+        allowNull: false,
       },
       message: {
         type: DataTypes.STRING,
-        allowNull: false
-      }
+        allowNull: false,
+      },
     },
     {
       sequelize,
+      freezeTableName: true,
       modelName: 'Chat',
     }
   );

--- a/src/database/models/notification.js
+++ b/src/database/models/notification.js
@@ -1,0 +1,54 @@
+import { Model } from 'sequelize';
+
+/**
+ * exporting the user model and it's features.
+ * @param {Object} sequelize
+ * @param {Object} DataTypes
+ * @returns {Object} the model for user
+ */
+export default (sequelize, DataTypes) => {
+  // eslint-disable-next-line require-jsdoc
+  class notifications extends Model {
+    // eslint-disable-next-line valid-jsdoc
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      notifications.belongsTo(models.users, {
+        as: 'receiver',
+        foreignKey: 'receiverId',
+      });
+    }
+  }
+  notifications.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        allowNull: false,
+        primaryKey: true,
+      },
+      isRead: {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false,
+      },
+      receiverId: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        references: {
+          model: 'users',
+          key: 'id',
+        },
+      },
+      message: DataTypes.STRING,
+      type: DataTypes.STRING,
+    },
+    {
+      sequelize,
+      modelName: 'notifications',
+    }
+  );
+  return notifications;
+};

--- a/src/database/models/users.js
+++ b/src/database/models/users.js
@@ -18,6 +18,10 @@ export default (sequelize, DataTypes) => {
     static associate(models) {
       users.hasOne(models.carts, { as: 'cart', foreignKey: 'userId' });
       users.hasMany(models.order, { as: 'orders', foreignKey: 'buyerId' });
+      users.hasMany(models.notifications, {
+        as: 'notifications',
+        foreignKey: 'receiverId',
+      });
       users.hasMany(models.Chat, {
         foreignKey: 'userId',
         as: 'chats',

--- a/src/database/seeders/20230328125840-notification-seeds.js
+++ b/src/database/seeders/20230328125840-notification-seeds.js
@@ -1,0 +1,41 @@
+import { faker } from '@faker-js/faker';
+// eslint-disable-next-line import/named
+import { users } from '../models';
+
+/** @type {import('sequelize-cli').Migration} */
+export default {
+  async up(queryInterface) {
+    const allUsers = await users.findAll({ where: { role: 'buyer' } });
+    const notifications = [];
+    // eslint-disable-next-line no-plusplus
+    for (let i = 0; i < 20; i++) {
+      const userIndex = faker.datatype.number({
+        min: 0,
+        max: allUsers.length - 1,
+      });
+
+      const notification = {
+        id: faker.datatype.uuid(),
+        message: faker.random.words(10),
+        type: faker.helpers.shuffle([
+          'products',
+          'payment',
+          'news',
+          'updates',
+        ])[0],
+        receiverId: allUsers[userIndex].dataValues.id,
+        isRead: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      notifications.push(notification);
+    }
+
+    await queryInterface.bulkInsert('notifications', notifications);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.bulkDelete('notifications', null, {});
+  },
+};

--- a/src/docs/notification.yml
+++ b/src/docs/notification.yml
@@ -1,0 +1,131 @@
+/notification:
+  get:
+    summary: Get user notifications
+    tags:
+      - Notifications
+    security:
+      - {}
+      - bearerAuth: []
+    responses:
+      '200':
+        description: Notifications were marked as read
+        schema:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              message:
+                type: string
+              type:
+                type: string
+              receiverId:
+                type: string
+              isRead:
+                type: boolean
+              
+
+/notification/read/all:
+  post:
+    summary: Mark all notifications as read
+    tags:
+      - Notifications
+    security:
+      - {}
+      - bearerAuth: []
+    responses:
+      '200':
+        description: User notifications were marked as read
+        schema:
+          type: object
+          properties:
+            message:
+              type: string
+      '500':
+        description: Internal server
+        schema:
+        type: object
+        properties:
+          message:
+            type: string
+
+/notification/read/{notificationId}:
+  post:
+    summary: Mark one notification as read
+    tags:
+      - Notifications
+    security:
+      - {}
+      - bearerAuth: []
+    parameters:
+      - in: path
+        name: notificationId
+        required: true
+        description: Notification ID
+        schema:
+          type: string
+
+    responses:
+      '200':
+        description: Notifications that was marked as read
+        schema:
+          type: object
+          properties:
+            id:
+              type: string
+            message:
+              type: string
+            type:
+              type: string
+            receiverId:
+              type: string
+            isRead:
+              type: boolean
+      '500':
+        description: Internal server
+        schema:
+        type: object
+        properties:
+          message:
+            type: string
+
+/notification/unread/{notificationId}:
+  post:
+    summary: Mark one notification as unread
+    tags:
+      - Notifications
+    security:
+      - {}
+      - bearerAuth: []
+    parameters:
+      - in: path
+        name: notificationId
+        required: true
+        description: Notification ID
+        schema:
+          type: string
+
+    responses:
+      '200':
+        description: Notifications that was marked as unread
+        schema:
+          type: object
+          properties:
+            id:
+              type: string
+            message:
+              type: string
+            receiverId:
+              type: string
+            type:
+              type: string
+            isRead:
+              type: boolean
+      '500':
+        description: Internal server
+        schema:
+        type: object
+        properties:
+          message:
+            type: string

--- a/src/docs/reviews.yml
+++ b/src/docs/reviews.yml
@@ -187,7 +187,7 @@
       - in: path
         name: id
         schema:
-          type: integer
+          type: string
         required: true
         description: ID of the review to delete
     responses:

--- a/src/docs/wishlist.js
+++ b/src/docs/wishlist.js
@@ -75,4 +75,107 @@
 *               properties:
 *                 message:
 *                   type: string
+*@swagger
+* /wishlist/all:
+*   get:
+*     summary: getting  wishlist of a all users
+*     tags:
+*         - Wishlist
+*     security:
+*       - bearerAuth: []
+*     responses:
+*       '200':
+*         description: You have Successfully all wishlists for all users
+*         content:
+*           application/json:
+*             schema:
+*               type: object
+*               properties:
+*                 product:
+*                   type: object
+*       '401':
+*         description: User not admin
+*         content:
+*           application/json:
+*             schema:
+*               type: object
+*               properties:
+*                 message:
+*                   type: string
+*@swagger
+* /wishlist/clear:
+*   patch:
+*     summary: clearing wishlist of user
+*     tags:
+*         - Wishlist
+*     security:
+*       - bearerAuth: []
+*     responses:
+*       '200':
+*         description: You have Successfully cleared your wsihlist
+*         content:
+*           application/json:
+*             schema:
+*               type: object
+*               properties:
+*                 product:
+*                   type: object
+*       '401':
+*         description: User not admin
+*         content:
+*           application/json:
+*             schema:
+*               type: object
+*               properties:
+*                 message:
+*                   type: string
+* @swagger
+* /wishlist/{id}:
+*   delete:
+*     summary: removing product from wishlist
+*     tags:
+*         - Wishlist
+*     security:
+*       - bearerAuth: []
+*     parameters:
+*       - in: path
+*         name: id
+*         required: true
+*         description: The id of the product to bedeleted from wishlist
+*         schema:
+*           type: string
+*     responses:
+*       '200':
+*         description: productproduct deleted from wishlist
+*         content:
+*           application/json:
+*             schema:
+*               type: object
+*               properties:
+*                 message:
+*                   type: string
+*                   description: A success message.
+*       '404':
+*         description: product not found
+*         content:
+*           application/json:
+*             schema:
+*               type: object
+*               properties:
+*                 statusCode:
+*                   type: integer
+*                   example: 404
+*                 message:
+*                   type: string
+*                   description: An error message.
+*       '500':
+*         description: Internal server error occurred.
+*         content:
+*           application/json:
+*             schema:
+*               type: object
+*               properties:
+*                 Error:
+*                   type: string
+*                   description: The error message
 */

--- a/src/helpers/socket.util.js
+++ b/src/helpers/socket.util.js
@@ -1,0 +1,19 @@
+/* eslint-disable */
+import { Server } from 'socket.io';
+
+export class SocketUtil {
+  // static io = {};
+  constructor() {}
+  static socketEmit(key, data) {
+    SocketUtil.io.sockets.emit(key, data);
+  }
+  static config(server) {
+    SocketUtil.io = new Server(server, { cors: { origin: '*' } });
+
+    SocketUtil.io.on('connection', () => {});
+    SocketUtil.io.on('disconnect', () => {});
+  }
+}
+export const knownSockets = {
+  notification: 'notification',
+};

--- a/src/middlewares/notification.middleware.js
+++ b/src/middlewares/notification.middleware.js
@@ -1,0 +1,40 @@
+import NotificationService from '../services/notification.services';
+
+export const checkIfHasUnread = async (req, res, next) => {
+  const unRead = await NotificationService.getNotifications(
+    {
+      receiverId: req.user.id,
+      isRead: false,
+    },
+    null,
+    null
+  );
+  if (unRead.rows.length === 0) {
+    return res
+      .status(404)
+      .json({ message: 'You do not have unread notifications' });
+  }
+  next();
+};
+
+export const checkIfHasNotificationId = async (req, res, next) => {
+  const notification = await NotificationService.getNotifications(
+    {
+      id: req.params.notificationId,
+    },
+    null,
+    null
+  );
+  if (notification.rows.length === 0) {
+    return res.status(404).json({ message: 'Notification not found' });
+  }
+  next();
+};
+
+export const receivedPaginationFormat = async (req, res, next) => {
+  req.query = {
+    limit: req.query.limit || '10',
+    page: req.query.page || '1',
+  };
+  next();
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -7,7 +7,7 @@ import cart from './cart';
 import reviews from './reviews.routes';
 import checkoutRoutes from './checkout';
 import chat from './chat';
-
+import notification from './notification';
 const routes = express();
 
 routes.get('/home', HomeControllers.welcome);
@@ -18,4 +18,5 @@ routes.use('/reviews', reviews);
 routes.use('/cart', cart);
 routes.use('/checkout', checkoutRoutes);
 routes.use('/chat', chat);
+routes.use('/notification', notification);
 export default routes;

--- a/src/routes/notification.js
+++ b/src/routes/notification.js
@@ -1,0 +1,23 @@
+import express from 'express';
+import NotificationController from '../controllers/notification.controller';
+import catchError from '../middlewares/catchError';
+import isAuthenticated from '../middlewares/verifyToken';
+const router = express.Router();
+router.get('/', isAuthenticated, NotificationController.getAllNotifications);
+router.post(
+  '/read/all',
+  isAuthenticated,
+  catchError(NotificationController.markAllAsRead)
+);
+router.post(
+  '/read/:notificationId',
+  isAuthenticated,
+  catchError(NotificationController.markAsRead)
+);
+router.post(
+  '/unread/:notificationId',
+  isAuthenticated,
+  catchError(NotificationController.markAsUnread)
+);
+
+export default router;

--- a/src/services/notification.services.js
+++ b/src/services/notification.services.js
@@ -1,0 +1,53 @@
+/* eslint-disable require-jsdoc */
+// eslint-disable-next-line import/named
+import { notifications } from '../database/models';
+
+export default class NotificationServices {
+  static async getAllNotifications(id) {
+    const notificationz = await notifications.findAll({
+      where: { receiverId: id },
+    });
+    return notificationz;
+  }
+
+  static async markAllNotificationAsRead(userId, res) {
+    await notifications.update(
+      {
+        isRead: true,
+      },
+      { where: { receiverId: userId } }
+    );
+    return res.status(200).json({ message: 'All notifications are read' });
+  }
+
+  static async markNotificationAsReadOrUnread(
+    notificationId,
+    res,
+    isRead = true
+  ) {
+    const notification = await notifications.findOne({
+      where: { id: notificationId },
+    });
+    if (!notification) {
+      return res.status(404).json({ message: 'Notification not found' });
+    }
+    notification.isRead = isRead;
+    await notification.save();
+    return res.json(notification);
+  }
+
+  static async deleteNotification(data) {
+    const notification = await notifications.findOne({
+      where: { id: data.notId },
+    });
+    if (!notification) {
+      return 'not exist';
+    }
+    if (notification.recipientId !== data.userId) {
+      return 'forbidden';
+    }
+    await notification.destroy({
+      where: { id: data.notId, recipientId: data.userId },
+    });
+  }
+}

--- a/src/services/product.services.js
+++ b/src/services/product.services.js
@@ -178,14 +178,16 @@ export default class Product {
       ],
     };
     if (categry) {
-      const cat = await category.findAll({ where: { title: { [Op.iLike]: `%${categry}%` } } });
+      const cat = await category.findAll({
+        where: { title: { [Op.iLike]: `%${categry}%` } },
+      });
       const ids = cat.map((item) => Number(item.id));
       if (cat) {
-        where.category = { [Op.in]: ids };
+        where.category = { [Op.in]: ids || [] };
       }
     }
     const product = await products.findAll({
-      where
+      where,
     });
 
     return product;

--- a/tests/login-mfa.test.js
+++ b/tests/login-mfa.test.js
@@ -26,7 +26,6 @@ let authToken = '';
 before('Clear everyting from test db before testing', async () => {
   const res = await chai.request(app).post('/users/signup').send(testUserData);
   // eslint-disable-next-line no-console
-  console.log(res);
   expect(res).to.have.status(201);
   expect(res.body.user).to.have.a.property('id');
   expect(res.body.user).to.have.a.property('email_token');

--- a/tests/read-unread-notification.test.js
+++ b/tests/read-unread-notification.test.js
@@ -1,0 +1,87 @@
+import { faker } from '@faker-js/faker';
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import env from 'dotenv';
+import app from '../src/app'; // assuming your app's entry point is in app.js
+// eslint-disable-next-line import/named
+import { users, notifications } from '../src/database/models';
+
+const { expect } = chai;
+
+env.config();
+chai.use(chaiHttp);
+
+let sampleNotification;
+let authToken;
+let userId;
+
+describe('Read/Unread notifications API', () => {
+  before(async () => {
+    sampleNotification = await notifications.findOne({
+      include: { model: users, as: 'receiver' },
+    });
+    const receiver = sampleNotification.receiver.dataValues;
+    userId = receiver.id;
+
+    const login = await chai
+      .request(app)
+      .post('/users/login')
+      .send({ email: receiver.email, password: '123@Pass' });
+    authToken = login.body.token;
+    expect(login).to.have.status(200);
+  });
+
+  it("should return 404 when notification don't exist", async () => {
+    const res = await chai
+      .request(app)
+      .post(`/notification/read/${faker.datatype.uuid()}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send();
+
+    expect(res).to.have.status(404);
+    expect(res.body).to.have.property('message');
+    expect(res.body.message).to.equal('Notification not found');
+  });
+
+  it('should mark notification as READ', async () => {
+    const res = await chai
+      .request(app)
+      .post(`/notification/read/${sampleNotification.id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send();
+
+    expect(res).to.have.status(200);
+    expect(res.body).to.be.an('object');
+    expect(res.body.isRead).to.equal(true);
+  });
+
+  it('should mark notification as UNREAD', async () => {
+    const res = await chai
+      .request(app)
+      .post(`/notification/unread/${sampleNotification.id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send();
+
+    expect(res).to.have.status(200);
+    expect(res.body).to.be.an('object');
+    expect(res.body.isRead).to.equal(false);
+  });
+
+  it('should mark all notification as READ', async () => {
+    const res = await chai
+      .request(app)
+      .post('/notification/read/all')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send();
+
+    const unreadNotifications = await notifications.findAll({
+      where: { receiverId: userId, isRead: false },
+    });
+
+    expect(res).to.have.status(200);
+    expect(res.body).to.have.property('message');
+    expect(res.body.message).to.equal('All notifications are read');
+    expect(unreadNotifications).to.be.an('array');
+    expect(unreadNotifications.length).to.equal(0);
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
This PR adds the ability to mark notifications as read, or unread
#### Description of Task to be completed?
A user should be able to mark one/all Notification as read
#### How should this be manually tested?
- run `npm install && npm run migrate:all && npm start`
- Visit `/api-docs` and you should see `notifications` section in the `swagger` documentation -- use that for testing.
#### Any background context you want to provide?
n/a
#### What are the relevant pivotal tracker/Trello stories?
https://www.pivotaltracker.com/n/projects/2632830/stories/184581357
#### Screenshots (if appropriate)
<img width="1135" alt="Screenshot 2023-03-28 at 16 06 52" src="https://user-images.githubusercontent.com/57767759/228287858-f0c6e501-4bd3-4bba-9f31-88a0172af7a6.png">
<img width="1439" alt="Screenshot 2023-03-28 at 17 08 51" src="https://user-images.githubusercontent.com/57767759/228287892-1ff3d38f-cb83-4ae9-94a5-b8737fb83ea5.png">

#### Questions:
n/a